### PR TITLE
Add demo tensor dataset

### DIFF
--- a/data/synthetic/demo_tensors/README.md
+++ b/data/synthetic/demo_tensors/README.md
@@ -1,0 +1,13 @@
+# Demo Tensors
+
+This folder contains a small synthetic dataset of NumPy tensors generated with
+`scripts/generate_tensors.py`.
+
+## Files
+
+- `demo_tensors.npz` – compressed archive containing two tensors:
+  - `tensor_a`: shape `(100, 3)`
+  - `tensor_b`: shape `(50, 10, 3)`
+
+The tensors are randomly generated using `numpy.random.rand` and can be loaded
+with `numpy.load`.

--- a/data/synthetic/demo_tensors/demo_tensors.npz
+++ b/data/synthetic/demo_tensors/demo_tensors.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d72e3ad47560149d848fce6184f6741ffa676cd1d560b25bf1f2181e14401b2
+size 14918

--- a/notebooks/demo_tensors.ipynb
+++ b/notebooks/demo_tensors.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo Tensors\n",
+    "\n",
+    "This notebook demonstrates how to run `scripts/generate_tensors.py` to create\n",
+    "a small dataset of NumPy tensors and how to load them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python ../scripts/generate_tensors.py ../data/synthetic/demo_tensors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "data = np.load('../data/synthetic/demo_tensors/demo_tensors.npz')\n",
+    "data.files, data['tensor_a'].shape, data['tensor_b'].shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/generate_tensors.py
+++ b/scripts/generate_tensors.py
@@ -1,0 +1,31 @@
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+def generate_tensors(output_dir: Path) -> None:
+    """Generate example tensors and save them to ``output_dir`` as ``demo_tensors.npz``.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory where the tensor file will be written.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tensor_a = np.random.rand(100, 3)
+    tensor_b = np.random.rand(50, 10, 3)
+
+    np.savez(output_dir / "demo_tensors.npz", tensor_a=tensor_a, tensor_b=tensor_b)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate demo tensor dataset")
+    parser.add_argument("output_dir", type=Path, help="Directory to write dataset")
+    args = parser.parse_args()
+    generate_tensors(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small script to create demo tensors
- document tensor shapes in a README
- show usage in a notebook
- generate and track demo tensors with Git LFS

## Testing
- `python scripts/generate_tensors.py data/synthetic/demo_tensors`


------
https://chatgpt.com/codex/tasks/task_e_68451bfc55d48331855f72a001c428f7