### PR TITLE
Add deterministic tensor generation

### DIFF
--- a/data/synthetic/demo_tensors/README.md
+++ b/data/synthetic/demo_tensors/README.md
@@ -17,7 +17,8 @@
     - `simulation_data`: A 5D tensor of shape `(5, 6, 6, 3, 2)`, representing higher-dimensional data.
 - **Generation Steps**:
     1. Navigate to the root of the repository.
-    2. Run the command: `python scripts/generate_tensors.py data/synthetic/demo_tensors`
+    2. Run the command: `python scripts/generate_tensors.py data/synthetic/demo_tensors --seed 123`
+       (the `--seed` option ensures deterministic output; omit it for random data)
     3. This will create/overwrite `data/synthetic/demo_tensors/demo_tensors.h5` with all the listed tensors.
 
 ## Setup and Usage

--- a/notebooks/demo_tensors.ipynb
+++ b/notebooks/demo_tensors.ipynb
@@ -29,7 +29,7 @@
     "`tensor_a`, `tensor_b`, `scalar_data`, `vector_data`, `image_grayscale_data`, `image_rgb_data`, `video_frames_data`, and `simulation_data`.\n",
     "\n",
     "Since this notebook is in the `notebooks/` directory, we use `../` to correctly path to the script and the output directory.\n",
-    "This command will create (or overwrite) `../data/synthetic/demo_tensors/demo_tensors.h5`."
+    "This command will create (or overwrite) `../data/synthetic/demo_tensors/demo_tensors.h5`. Use `--seed` for deterministic output."
    ]
   },
   {
@@ -39,8 +39,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python ../scripts/generate_tensors.py ../data/synthetic/demo_tensors"
-   ]
+    "!python ../scripts/generate_tensors.py ../data/synthetic/demo_tensors --seed 123"
+  ]
   },
   {
    "cell_type": "markdown",

--- a/scripts/generate_tensors.py
+++ b/scripts/generate_tensors.py
@@ -5,14 +5,19 @@ import numpy as np
 import h5py
 
 
-def generate_tensors(output_dir: Path) -> None:
+def generate_tensors(output_dir: Path, seed: int | None = None) -> None:
     """Generate example tensors and save them to ``output_dir`` as ``demo_tensors.h5``.
 
     Parameters
     ----------
     output_dir : Path
         Directory where the tensor file will be written.
+    seed : int, optional
+        Random seed passed to ``numpy.random.seed`` for deterministic output.
     """
+    if seed is not None:
+        np.random.seed(seed)
+
     output_dir.mkdir(parents=True, exist_ok=True)
     output_file = output_dir / "demo_tensors.h5"
 
@@ -56,8 +61,9 @@ def generate_tensors(output_dir: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate demo tensor dataset in HDF5 format")
     parser.add_argument("output_dir", type=Path, help="Directory to write dataset")
+    parser.add_argument("--seed", type=int, default=None, help="Optional random seed for reproducible output")
     args = parser.parse_args()
-    generate_tensors(args.output_dir)
+    generate_tensors(args.output_dir, seed=args.seed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow passing an optional seed to `generate_tensors`
- expose `--seed` argument in the CLI
- document deterministic generation in README and notebook

## Testing
- `python -m py_compile scripts/generate_tensors.py`
- `python scripts/generate_tensors.py data/synthetic/demo_tensors --seed 42`

------
https://chatgpt.com/codex/tasks/task_e_684545d25e1083319e75a3ca14b5ec6e